### PR TITLE
added support for webapp

### DIFF
--- a/headly_server.js
+++ b/headly_server.js
@@ -1,21 +1,24 @@
 (function () {
-  if (typeof Fiber === "undefined") {
-    Fiber = Npm.require("fibers");
-  }
+	var ConnectHandler = __meteor_bootstrap__.app || WebApp.connectHandlers;
+	
+    if (typeof Fiber === "undefined") {
+    	Fiber = Npm.require("fibers");
+    }
+
     if (!Meteor.headly) {	 
-	Meteor.headly = {};
+		Meteor.headly = {};
     }
     
     if (!Meteor.headly._options) {
-	Meteor.headly._options = {};
+		Meteor.headly._options = {};
     }
     
     Meteor.headly.config = function(options) {
-	Meteor.headly._options = options || Meteor.headly._options;
+		Meteor.headly._options = options || Meteor.headly._options;
     };
-    
-    __meteor_bootstrap__.app
-	.use(function(req, res, next) {
+
+
+	ConnectHandler .use(function(req, res, next) {
 	    if (req.headers['user-agent'].indexOf('facebookexternalhit') !== -1) {
 		res.writeHead(200, {'Content-Type': 'text/html'});
 		Fiber(function () {

--- a/package.js
+++ b/package.js
@@ -4,5 +4,9 @@ Package.describe({
 
 
 Package.on_use(function (api) {
-		   api.add_files('headly_server.js', 'server');
-	       });
+	api.add_files('headly_server.js', 'server');
+
+	if (typeof api.export !== 'undefined') {
+		api.use('webapp', 'server');
+	}
+});


### PR DESCRIPTION
I fixed the issue I was having here where newer meteor apps use 

```
WebApp.connectHandler 
```

instead of:

```
__meteor_bootstrap__.app
```

It now works in Meteor 0.7 as well as older versions. 
